### PR TITLE
fix(description_parser): if an enumerationType only had a single enumeration the parsing would fail

### DIFF
--- a/src/homeconnect_websocket/description_parser.py
+++ b/src/homeconnect_websocket/description_parser.py
@@ -67,13 +67,7 @@ def add_enum_subsets(features: FeatureMap, description: list[dict]) -> None:
             ):
                 super_enum = features["enumeration"][int(enum["@subsetOf"], base=16)]
                 subset_enum = {}
-
-                # Ensure enumeration is always a list
-                enumeration_list = enum["enumeration"]
-                if not isinstance(enumeration_list, list):
-                    enumeration_list = [enumeration_list]
-
-                for value in enumeration_list:
+                for value in enum["enumeration"]:
                     subset_enum[int(value["@value"])] = super_enum[int(value["@value"])]
                 features["enumeration"][int(enum["@enid"], base=16)] = subset_enum
 
@@ -239,6 +233,8 @@ def parse_device_description(
                 "commandList",
                 "program",
                 "programGroup",
+                "enumeration",
+                "enumerationType",
             ),
         )["device"]
     except ExpatError as exc:

--- a/src/homeconnect_websocket/description_parser.py
+++ b/src/homeconnect_websocket/description_parser.py
@@ -67,7 +67,13 @@ def add_enum_subsets(features: FeatureMap, description: list[dict]) -> None:
             ):
                 super_enum = features["enumeration"][int(enum["@subsetOf"], base=16)]
                 subset_enum = {}
-                for value in enum["enumeration"]:
+
+                # Ensure enumeration is always a list
+                enumeration_list = enum["enumeration"]
+                if not isinstance(enumeration_list, list):
+                    enumeration_list = [enumeration_list]
+
+                for value in enumeration_list:
                     subset_enum[int(value["@value"])] = super_enum[int(value["@value"])]
                 features["enumeration"][int(enum["@enid"], base=16)] = subset_enum
 

--- a/tests/DeviceDescription_short.xml
+++ b/tests/DeviceDescription_short.xml
@@ -26,6 +26,7 @@
         <event enumerationType="3001" handling="acknowledge" level="hint" refCID="03" refDID="80" uid="1009" />
         <eventList uid="0006">
             <event enumerationType="3001" handling="acknowledge" level="hint" refCID="03" refDID="80" uid="100A" />
+            <event enumerationType="3003" handling="acknowledge" level="hint" refCID="03" refDID="80" uid="100B" />
         </eventList>
     </eventList>
     <commandList access="writeOnly" available="true" uid="0007">
@@ -59,6 +60,9 @@
             <enumeration value="0" />
             <enumeration value="1" />
             <enumeration value="2" />
+        </enumerationType>
+        <enumerationType enid="3003" subsetOf="3001">
+            <enumeration value="1" />
         </enumerationType>
     </enumerationTypeList>
 </device>

--- a/tests/FeatureMapping_short.xml
+++ b/tests/FeatureMapping_short.xml
@@ -7,6 +7,7 @@
     <feature refUID="1006">Setting.2</feature>
     <feature refUID="1009">Event.1</feature>
     <feature refUID="100A">Event.2</feature>
+    <feature refUID="100B">Event.3</feature>
     <feature refUID="100D">Command.1</feature>
     <feature refUID="100E">Command.2</feature>
     <feature refUID="1011">Option.1</feature>

--- a/tests/test_description_parser.py
+++ b/tests/test_description_parser.py
@@ -436,6 +436,17 @@ REFERENCE_DISCRIPTION_SHORT = {
             "refCID": 3,
             "refDID": 128,
         },
+        {
+            "uid": 4107,
+            "name": "Event.3",
+            "contentType": "enumeration",
+            "protocolType": "Integer",
+            "enumeration": {"1": "Present"},
+            "handling": "acknowledge",
+            "level": "hint",
+            "refCID": 3,
+            "refDID": 128,
+        },
     ],
     "command": [
         {


### PR DESCRIPTION
If an enumerationType only had a single enumeration the parsing would fail
This ensures the iteration is always over a list.

Extended the short description test with such a case to verify it works.

This fixes the error found in https://github.com/chris-mc1/homeconnect_local_hass/issues/144

The linked description would fail at:
```
<enumerationType enid="8506" subsetOf="6501">
    <enumeration value="2"/>
</enumerationType>
```
and
```
<enumerationType enid="8507" subsetOf="6501">
    <enumeration value="3"/>
</enumerationType>
```