### PR TITLE
Fix ValueError when appliance sends uppercase execution value

### DIFF
--- a/src/homeconnect_websocket/entities.py
+++ b/src/homeconnect_websocket/entities.py
@@ -486,7 +486,7 @@ class Program(AvailableMixin, Entity):
     async def update(self, values: dict) -> None:
         """Update the entity state and execute callbacks."""
         if "execution" in values:
-            self._execution = Execution(values["execution"])
+            self._execution = Execution(values["execution"].lower())
         await super().update(values)
 
     def _build_options(


### PR DESCRIPTION
## Problem

Appliances can send the execution field in uppercase (e.g. "SELECTANDSTART"), but the Execution StrEnum defines values in lowercase ("selectandstart"). This caused a ValueError in _init() → _update_entities() → entity.update(), which was silently swallowed, leaving all entities without their initial state after connection.

```
ValueError: 'SELECTANDSTART' is not a valid Execution
```

Fix

Normalize the value to lowercase before constructing the enum, consistent with how Access is already handled at line 287:

```
  # before
  self._execution = Execution(values["execution"])

  # after
  self._execution = Execution(values["execution"].lower())
```

Notes
  - Access already applies .lower() — this brings Execution in line with that pattern
  - EventHandling and EventLevel are only populated from the static XML description (not live appliance messages), so they are not affected
  
Relevant to https://github.com/chris-mc1/homeconnect_local_hass/pull/332/