### PR TITLE
Force the execution to lowercase

### DIFF
--- a/src/homeconnect_websocket/entities.py
+++ b/src/homeconnect_websocket/entities.py
@@ -486,7 +486,7 @@ class Program(AvailableMixin, Entity):
     async def update(self, values: dict) -> None:
         """Update the entity state and execute callbacks."""
         if "execution" in values:
-            self._execution = Execution(values["execution"])
+            self._execution = Execution(values["execution"].lower())
         await super().update(values)
 
     def _build_options(


### PR DESCRIPTION
For backwards compatibility with previous versions of HomeConnect_Local_Hass versions