### PR TITLE
fix: restore exponential backoff in reconnect loop

### DIFF
--- a/src/homeconnect_websocket/session.py
+++ b/src/homeconnect_websocket/session.py
@@ -14,7 +14,12 @@ from Crypto.Random import get_random_bytes
 
 from homeconnect_websocket.task_manager import TaskManager
 
-from .const import DEFAULT_SEND_TIMEOUT, ERROR_CODES
+from .const import (
+    DEFAULT_SEND_TIMEOUT,
+    ERROR_CODES,
+    MAX_CONNECT_TIMEOUT,
+    TIMEOUT_INCREASE_FACTOR,
+)
 from .errors import (
     AllreadyConnectedError,
     AuthenticationError,
@@ -505,10 +510,12 @@ class HCSessionReconnect(HCSession):
     """HomeConnect Session with reconnect."""
 
     _reconnect: bool = True
+    _retry_count: int = 0
 
     async def connect(self) -> None:
         """Open Connection with Appliance."""
         self._reconnect = True
+        self._retry_count = 0
         if self.connection_state in (ConnectionState.RECONNECTING):
             raise AllreadyConnectedError
 
@@ -530,6 +537,7 @@ class HCSessionReconnect(HCSession):
                         self._wrap_recv_loop(), eager_start=True
                     )
                     await self._handshake(init_message)
+                    self._retry_count = 0
                     break
 
                 self._task_manager.create_background_task(
@@ -537,10 +545,17 @@ class HCSessionReconnect(HCSession):
                 )
                 self._logger.info("Connected, no handshake")
                 self._set_connection_state(ConnectionState.CONNECTED)
+                self._retry_count = 0
                 break
 
             except (ConnectionFailedError, aiohttp.ClientError):
-                self._logger.debug("Reconnect failed")
+                timeout = TIMEOUT_INCREASE_FACTOR**self._retry_count
+                self._retry_count += 1
+                self._logger.debug(
+                    "Reconnect failed, retrying in %.1fs",
+                    min(timeout, MAX_CONNECT_TIMEOUT),
+                )
+                await asyncio.sleep(min(timeout, MAX_CONNECT_TIMEOUT))
                 continue
             except HCHandshakeError:
                 self._logger.debug("Reconnect failed")


### PR DESCRIPTION
## What

`HCSessionReconnect._reconnect_loop` retries `self._socket.connect()` with no delay between attempts — a bare `continue` on `ConnectionFailedError`/`aiohttp.ClientError`. During a real appliance outage this spins as fast as the TLS/TCP handshake fails, for the full duration of the outage.

## Why this is a regression, not a missing feature

Exponential backoff existed before: #717e85c "Improved reconnect" added `_retry_count` and used the (still-present-but-unused) `TIMEOUT_INCREASE_FACTOR`/`MAX_CONNECT_TIMEOUT` constants from `const.py` to back off between reconnect attempts, resetting on every successful connect/handshake. It was dropped when `_reconnect_loop` was rewritten in 0ca5d6c "rewritten session connect and reconnect logic" — the constants were left behind in `const.py`, unused, ever since.

This PR restores the same behavior against the current `HCSessionReconnect` structure: `_retry_count` resets in `connect()` and on every successful (re)connect in `_reconnect_loop`, and grows `TIMEOUT_INCREASE_FACTOR ** retry_count` seconds between failed attempts, capped at `MAX_CONNECT_TIMEOUT`.

## Related reports

- #62 — "Receive loop Exception" logged 4124 times for one user; consistent with a busy-loop hammering a genuinely offline device
- #274 (in `homeconnect_local_hass`) — feature request for smarter/quieter handling while an appliance is offline; this doesn't add offline detection, but it does stop the log/connection spam during it

## Testing

- `uv run ruff check src/` / `ruff format --check src/` — clean
- `sudo uv run pytest` (full suite, matches `test.yaml`) — 56 passed, including `test_session_reconnect_manual` and `test_session_reconnect_auto`

Happy to add a dedicated test asserting the backoff grows/resets if useful — didn't want to guess at how you'd want failure injected into the `ApplianceServer` test fixture.